### PR TITLE
Only publish Lua and type definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rbxts/object-event",
-  "version": "1.1.0",
+  "version": "1.0.1",
   "description": "Allows for custom events to be created for custom OOP implementations. Attempts to reproduce Roblox's syntax as closely as possible while adding more features.",
   "main": "init.lua",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "Connection"
   ],
   "files": [
-    "out",
+    "*.lua",
+    "*.d.ts",
   ],
   "author": "davness",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rbxts/object-event",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Allows for custom events to be created for custom OOP implementations. Attempts to reproduce Roblox's syntax as closely as possible while adding more features.",
   "main": "init.lua",
   "types": "index.d.ts",
@@ -17,6 +17,9 @@
     "Event",
     "Signal",
     "Connection"
+  ],
+  "files": [
+    "out",
   ],
   "author": "davness",
   "license": "MIT",


### PR DESCRIPTION
I believe the current published package in `npm` has too many things included (notably the `tsconfig.json` which confuses Rojo, as far as I can tell).

My understanding is that this change would mean it publishes only what's needed and expected.

Thanks for open sourcing this btw! Saved a lot of time reinventing the wheel 😄 